### PR TITLE
Increase episode steps for half_cheetah_vel

### DIFF
--- a/rlkit/envs/half_cheetah_vel.py
+++ b/rlkit/envs/half_cheetah_vel.py
@@ -43,6 +43,7 @@ class HalfCheetahVelEnv(HalfCheetahEnv):
 
         observation = self._get_obs()
         reward = forward_reward - ctrl_cost
+        self._step += 1
         done = False
         infos = dict(reward_forward=forward_reward,
             reward_ctrl=-ctrl_cost, task=self._task)


### PR DESCRIPTION
This fixes the issue that `half-cheetah-vel` generates infinitely long episodes without terminating at the specified `max_episode_steps`. Without fixing this part, users cannot collect data from the `half-cheetah-vel` env.